### PR TITLE
Add repo file descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@ Testing of OpenAI Codex.
 
 The dataset file `test.csv` has been moved into the `data/` directory.
 
+## Repository Files
+
+The repo contains a simple Python script and sample dataset:
+
+- **read-data.py** – reads `data/test.csv` with pandas and prints basic
+  statistics.
+- **data/test.csv** – bike rental dataset from Kaggle used for testing.
+
+
 
 ## dataset
 https://www.kaggle.com/datasets/aguado/bike-rental-data-set-uci


### PR DESCRIPTION
## Summary
- document repository files in README

## Testing
- `python3 read-data.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685a5da492148321bf2e00f3e626224f