### PR TITLE
Fix parsing of CSV padded with NULs

### DIFF
--- a/read-data.py
+++ b/read-data.py
@@ -1,12 +1,25 @@
 import pandas as pd
+import io
+
+
+def load_csv_clean(path: str) -> pd.DataFrame:
+    """Load a CSV that may be padded with NUL bytes."""
+    with open(path, "rb") as f:
+        content = f.read()
+
+    # Remove leading NUL bytes to avoid corrupt column names
+    content = content.lstrip(b"\x00")
+
+    return pd.read_csv(io.BytesIO(content), sep=";")
 
 def main():
     try:
-        df = pd.read_csv('data/test.csv')
+        df = load_csv_clean("data/test.csv")
     except Exception as e:
-        print(f'Error reading CSV: {e}')
+        print(f"Error reading CSV: {e}")
         return
-    print(df.describe(include='all'))
+
+    print(df.describe(include="all"))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- update `read-data.py` to handle leading NUL bytes
- strip null bytes and load CSV using a semicolon separator

## Testing
- `python3 read-data.py | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_685a5f9b74948321880fe1bfa1f9c83b