### PR TITLE
Add dataset column descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,20 @@ The repo contains a simple Python script and sample dataset:
   statistics.
 - **data/test.csv** – bike rental dataset from Kaggle used for testing.
 
-
-
 ## dataset
 https://www.kaggle.com/datasets/aguado/bike-rental-data-set-uci
+
+## Dataset Columns
+The `test.csv` file includes the following columns:
+
+- **id** – unique identifier for each record
+- **year** – year of the measurement
+- **hour** – hour of the day (0–23)
+- **season** – numeric code for the season
+- **holiday** – whether the day was a holiday
+- **workingday** – indicates a standard working day
+- **weather** – weather situation code
+- **temp** – recorded temperature in Celsius
+- **atemp** – perceived or "feels-like" temperature
+- **humidity** – relative humidity percentage
+- **windspeed** – wind speed value


### PR DESCRIPTION
## Summary
- clarify README with dataset column descriptions

## Testing
- `python3 read-data.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685a648f6a0483218f491beb713f3c66